### PR TITLE
Add Nil type

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,24 @@ fmt.Println("Pet's name is", j.Q(".name"))
 fmt.Println("Pet's category name is", j.Q(".category.name"))
 fmt.Println("First tag's name is", j.Q(".tags[0].name"))
 ```
-Depending on the JSON input the unmarshalled `fetch.J` could be one of these types implementing `fetch.J` 
+Depending on the JSON data type the queried `fetch.J` could be one of these types
 
-| Type    | Definition      |
-|---------|-----------------|
-| fetch.M | map[string]any  |
-| fetch.A | []any           |
-| fetch.F | float64         |
-| fetch.S | string          |
+| Type      | Go definition   | JSON data type                      |
+|-----------|-----------------|-------------------------------------|
+| fetch.M   | map[string]any  | object                              |
+| fetch.A   | []any           | array                               |
+| fetch.F   | float64         | number                              |
+| fetch.S   | string          | string                              |
+| fetch.Nil | (nil) *struct{} | null, undefined, anything not found |
  
-If you want `fetch.J` to return the value of the Definition type call method `fetch.J#Raw()`.
+If you want `fetch.J` to return the value of the definition type, call method `fetch.J#Raw()`.  
+E.g. check if `fetch.J` is `nil`
+```go
+j, _ := fetch.Unmarshal[fetch.J]("{}")
+if j.Q(".name").Raw() == nil {
+    // key 'name' doesn't exist
+}
+```
 
 Method `fetch.J#Q` returns `fetch.J`. You can use the method `Q` on the result as well.
 ```go

--- a/j_test.go
+++ b/j_test.go
@@ -51,11 +51,7 @@ func TestJ_Q(t *testing.T) {
 		//	fmt.Print()
 		//}
 
-		gotJ := j.Q(c.P)
-		var got any
-		if gotJ != nil {
-			got = gotJ.Raw()
-		}
+		got := j.Q(c.P).Raw()
 		if got != c.E {
 			t.Errorf("case #%d: wrong value, expected=%v, got=%v", i, c.E, got)
 		}
@@ -119,5 +115,26 @@ func TestJ_String(t *testing.T) {
 	var j J = M{"name": "Lola"}
 	if fmt.Sprint(j) != `{"name":"Lola"}` {
 		t.Errorf("J.String j inteface wrong value")
+	}
+}
+
+func TestJ_Nil(t *testing.T) {
+	j, err := Unmarshal[J](`{"name":"Lola"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if j.Q(".id") == nil {
+		t.Errorf("didn't expect J value to be nil")
+	}
+	fmt.Println(j.Q(".id"))
+	if j.Q(".id").Raw() != nil {
+		t.Errorf("expected id to be nil")
+	}
+	if j.Q(".id").String() != "nil" {
+		t.Errorf("expected id to print nil")
+	}
+	if j.Q(".id").Q(".yaid").Raw() != nil {
+		t.Errorf("expected id to be nil")
 	}
 }

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -36,23 +36,3 @@ func TestMarshalStruct(t *testing.T) {
 		}
 	}
 }
-
-type SA struct {
-	t        *testing.T
-	expected string
-}
-
-func (sa SA) assertMarshal(res string, err error) {
-	if err != nil {
-		sa.t.Fatalf("Marshal error: %s", err)
-	}
-	if sa.expected != string(res) {
-		sa.t.Errorf("Marshal result mismatch, got=%s, expected=%s", res, sa.expected)
-	}
-}
-
-func assertNil(a any) {
-	if a != nil {
-		panic(a)
-	}
-}


### PR DESCRIPTION
Fixes #4 
Introduces Nil type to `fetch.J`. Before it used to return plain nil. It is a breaking change, but the package has been out for 2 days. I don't think anyone is using it in the production already.