### PR TITLE
Add Parse function

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ fmt.Println("First sold pet ", j.Q(".[0]"))
 `fetch.J` is an interface with `Q` method which provides easy access to any field.   
 Method `fetch.J#String()` returns JSON formatted string of the value. 
 ```go
-j, err := fetch.Unmarshal[fetch.J](`{
+j := fetch.Parse(`{
     "name": "Jason",
     "category": {
         "name":"dogs"
@@ -178,27 +178,17 @@ j, err := fetch.Unmarshal[fetch.J](`{
         {"name":"briard"}
     ]
 }`)
-if err != nil {
-    panic(err)
-}
 
 fmt.Println("Print the whole json:", j)
 fmt.Println("Pet's name is", j.Q(".name"))
 fmt.Println("Pet's category name is", j.Q(".category.name"))
 fmt.Println("First tag's name is", j.Q(".tags[0].name"))
-```
+``` 
 Method `fetch.J#Q` returns `fetch.J`. You can use the method `Q` on the result as well.
 ```go
 category := j.Q(".category")
 fmt.Println("Pet's category object", category)
 fmt.Println("Pet's category name is", category.Q(".name"))
-```
-
-`fetch.JQ` is a helper function to parse JSON into `fetch.J` and query it.
-```go
-jsonStr := `{"category": {"name":"dogs"}}`
-name := fetch.JQ(jsonStr, ".category.name")
-fmt.Println("Category name:", name)
 ```
 
 To convert `fetch.J` to a basic value use one of `As*` methods
@@ -213,7 +203,7 @@ To convert `fetch.J` to a basic value use one of `As*` methods
 
 E.g.
 ```go
-n, ok := fetch.JQ(`{"price": 14.99}`, ".price").AsNumber()
+n, ok := fetch.Parse(`{"price": 14.99}`).Q(".price").AsNumber()
 if !ok {
     // not a number
 }
@@ -222,11 +212,11 @@ fmt.Printf("Price: %.2f\n", n) // n is a float64
 
 Use `IsNil` to check the value on presence.
 ```go
-if fetch.JQ("{}", ".price").IsNil() {
+if fetch.Parse("{}").Q(".price").IsNil() {
     fmt.Println("key 'price' doesn't exist")
 }
 // fields of unknown values are nil as well.
-if fetch.JQ("{}", ".price.cents").IsNil() {
+if fetch.Parse("{}").Q(".price.cents").IsNil() {
     fmt.Println("'cents' of undefined is fine.")
 }
 ```
@@ -238,7 +228,7 @@ To convert any object into a string, which is treating public struct fields as d
 ```go
 str, err := fetch.Marhsal(map[string]string{"key":"value"})
 ```
-#### Unmarshal
+#### Unmarshalling
 Unmarshal will parse the input into the generic type.
 ```go
 type Pet struct {
@@ -249,6 +239,12 @@ if err != nil {
     panic(err)
 }
 fmt.Println(p.Name)
+```
+
+`fetch.Parse` unmarshalls JSON string into `fetch.J`, returning `fetch.Nil` instead of an error,
+which allows you to write one-liners. 
+```go
+fmt.Println(fetch.Parse(`{"name":"Jason"}`).Q(".name"))
 ```
 
 ### Global Setters

--- a/fetch.go
+++ b/fetch.go
@@ -54,13 +54,23 @@ func requestWithBody[T any](url string, method string, body any, config ...Confi
 		config = []Config{{}}
 	}
 	config[0].Method = method
-	b, err := StringifySafe(body)
+	b, err := bodyToString(body)
 	if err != nil {
 		var t T
 		return t, nonHttpErr("invalid body: ", err)
 	}
 	config[0].Body = b
 	return Request[T](url, config...)
+}
+
+func bodyToString(v any) (string, error) {
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	if s, ok := v.([]byte); ok {
+		return string(s), nil
+	}
+	return Marshal(v)
 }
 
 func Delete[T any](url string, config ...Config) (T, *Error) {

--- a/j.go
+++ b/j.go
@@ -19,7 +19,7 @@ import (
 // | fetch.B   | bool            | boolean                             |
 // | fetch.Nil | (nil) *struct{} | null, undefined, anything not found |
 type J interface {
-	// Q parses JQ-like patterns and returns according to the path value.
+	// Q parses jq-like patterns and returns according to the path value.
 	// E.g.
 	//{
 	//  "name": "Jason",
@@ -295,14 +295,11 @@ func (n Nil) AsString() (string, bool)         { return "", false }
 func (n Nil) AsBoolean() (bool, bool)          { return false, false }
 func (n Nil) IsNil() bool                      { return true }
 
-// JQ unmarshals jsonStr into fetch.J
+// Deprecated, use fetch.Parse(jsonStr).Q(pattern)
+// JQ parses jsonStr into fetch.J
 // and calls J.Q method with the pattern.
 func JQ(jsonStr, pattern string) J {
-	j, err := Unmarshal[J](jsonStr)
-	if err != nil {
-		return jnil
-	}
-	return j.Q(pattern)
+	return Parse(jsonStr).Q(pattern)
 }
 
 func isJNil(v any) bool {

--- a/j.go
+++ b/j.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 )
 
-var jnil Nil
-
 // J represents arbitrary JSON.
 // Depending on the JSON data type the queried `fetch.J` could be one of these types
 //
@@ -182,7 +180,7 @@ func parseValue(v any, remaining string, sep string) J {
 	panic("glossd/fetch panic, please report to github: array only expected . or [ ")
 }
 
-// F represents a JSON number
+// F represents a JSON number.
 type F float64
 
 func (f F) Q(pattern string) J {
@@ -210,7 +208,7 @@ func (f F) AsString() (string, bool)         { return "", false }
 func (f F) AsBoolean() (bool, bool)          { return false, false }
 func (f F) IsNil() bool                      { return false }
 
-// S can't be a root value.
+// S can't be the root of J tree. Type string alone is not a valid JSON.
 type S string
 
 func (s S) Q(pattern string) J {
@@ -268,10 +266,15 @@ func (b B) IsNil() bool                      { return false }
 
 type nilStruct struct{}
 
-// Nil represents any not found value. The pointer's value is always nil.
+// Nil represents any not found or null values. The pointer's value is always nil.
+// However, when returned from any method, it doesn't equal nil, because
+// a Go interface is not nil when it has a type.
 // It exists to prevent nil pointer dereference when retrieving Raw value.
-// Nil can't be a root value.
+// It can be the root in J tree, because null alone is a valid JSON.
 type Nil = *nilStruct
+
+// the single instance of Nil.
+var jnil Nil
 
 func (n Nil) Q(string) J {
 	return n

--- a/j.go
+++ b/j.go
@@ -180,7 +180,7 @@ func parseValue(v any, remaining string, sep string) J {
 	panic("glossd/fetch panic, please report to github: array only expected . or [ ")
 }
 
-// F represents a JSON number.
+// F represents JSON number.
 type F float64
 
 func (f F) Q(pattern string) J {
@@ -208,7 +208,7 @@ func (f F) AsString() (string, bool)         { return "", false }
 func (f F) AsBoolean() (bool, bool)          { return false, false }
 func (f F) IsNil() bool                      { return false }
 
-// S can't be the root of J tree. Type string alone is not a valid JSON.
+// S represents JSON string.
 type S string
 
 func (s S) Q(pattern string) J {

--- a/parse.go
+++ b/parse.go
@@ -6,12 +6,15 @@ import (
 	"reflect"
 )
 
-// todo
-//// Instead of panicking skips any invalid fields.
-//func Parse[T any](j string) T {
-//	var t T
-//	return t
-//}
+// Parse unmarshalls the JSON string into fetch.J without panicking.
+// If unmarshalling encounters an error, Parse returns fetch.Nil type.
+func Parse(s string) J {
+	j, err := Unmarshal[J](s)
+	if err != nil {
+		return jnil
+	}
+	return j
+}
 
 // UnmarshalJ sends J.String() to Unmarshal.
 func UnmarshalJ[T any](j J) (T, error) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -52,3 +52,14 @@ func TestUnmarshalJ(t *testing.T) {
 		t.Errorf("UnmarshalJ result mismatch, got=%s", r)
 	}
 }
+
+func TestParse(t *testing.T) {
+	num, ok := Parse(`{"num":1}`).Q("num").AsNumber()
+	if !ok || num != 1 {
+		t.Errorf("parsing failed")
+	}
+
+	if !Parse("{whatisthis?").IsNil() {
+		t.Errorf("wrong json should return nil")
+	}
+}

--- a/stringify.go
+++ b/stringify.go
@@ -6,23 +6,19 @@ import (
 
 // Stringify tries to marshal v.
 // If an error happens, Stringify returns an empty string.
-func Stringify(v any) string {
-	s, err := StringifySafe(v)
-	if err != nil {
-		return ""
-	}
-	return s
-}
+// An empty string is not a valid JSON, indicating Stringify failed.
+//func Stringify(v any) string {
+//	s, err := StringifySafe(v)
+//	if err != nil {
+//		return ""
+//	}
+//	return s
+//}
 
 // StringifySafe tries to fix possible errors during marshalling and then calls Marshal.
 func StringifySafe(v any) (string, error) {
-	if s, ok := v.(string); ok {
-		return s, nil
-	}
-	if s, ok := v.([]byte); ok {
-		return string(s), nil
-	}
-	//todo add more edge cases e.g. channel fields
+	//todo skip unsupported types e.g. channel fields
+	// I can't rely on Go's encoding/json to escape unsupported fields.
 	return Marshal(v)
 }
 

--- a/stringify.go
+++ b/stringify.go
@@ -4,12 +4,17 @@ import (
 	"github.com/glossd/fetch/internal/json"
 )
 
-// todo
-// Instead of panicking skips any invalid types or fields.
-//func Stringify(v any) string {
-//	return ""
-//}
+// Stringify tries to marshal v.
+// If an error happens, Stringify returns an empty string.
+func Stringify(v any) string {
+	s, err := StringifySafe(v)
+	if err != nil {
+		return ""
+	}
+	return s
+}
 
+// StringifySafe tries to fix possible errors during marshalling and then calls Marshal.
 func StringifySafe(v any) (string, error) {
 	if s, ok := v.(string); ok {
 		return s, nil
@@ -17,6 +22,7 @@ func StringifySafe(v any) (string, error) {
 	if s, ok := v.([]byte); ok {
 		return string(s), nil
 	}
+	//todo add more edge cases e.g. channel fields
 	return Marshal(v)
 }
 

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -36,9 +36,3 @@ func TestMarshalStruct(t *testing.T) {
 		}
 	}
 }
-
-func TestStringify(t *testing.T) {
-	if Stringify(make(chan bool)) != "" {
-		t.Errorf("should have defaulted to an empty string")
-	}
-}

--- a/stringify_test.go
+++ b/stringify_test.go
@@ -36,3 +36,9 @@ func TestMarshalStruct(t *testing.T) {
 		}
 	}
 }
+
+func TestStringify(t *testing.T) {
+	if Stringify(make(chan bool)) != "" {
+		t.Errorf("should have defaulted to an empty string")
+	}
+}


### PR DESCRIPTION
Long planned Parse function!
I chose `Parse` to return `fetch.J` instead of having a type parameter, because `Parse` just like `fetch.J` is for convenience and simplicity. Whereas if I specify the type, I would like certainty. 
`Stringify` needs its own marshaller which I'm not ready to implement for now.
`StringifySafe` will stay for backward compatibility