### PR TITLE
ResponseEmpty error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fmt.Println("First tag's name is ", pet.Tags[0].Name) // handle index
 Post, Put and others have an additional argument for the request body of `any` type. 
 ```go
 type Pet struct {
-	Name string
+    Name string
 }
 type IdObj struct {
     Id int
@@ -112,17 +112,18 @@ If you don't need the HTTP body you can use `fetch.ResponseEmpty`
 ```go
 res, err := fetch.Delete[fetch.ResponseEmpty]("https://petstore.swagger.io/v2/pet/10")
 if err != nil {
-	panic(err)
+    panic(err)
 }
 fmt.Println("Status:", res.Status)
 fmt.Println("Headers:", res.Headers())
 ```
 #### Error handling
-The error will contain the status and other http attributes
+The error will contain the status and other http attributes. Any non-2xx response status is treated as an error.
 ```go
 _, err := fetch.Get[string]("https://petstore.swagger.io/v2/pet/-1")
 if err != nil {
-    fmt.Printf("Get pet failed with status %d: %s", err.Status, err.Msg)
+    fmt.Printf("Get pet failed: %s", err)
+    fmt.Printf("HTTP status=%d, headers=%v, body=%s", err.Status, err.Headers, err.Body)
 }
 ```
 ### Make request with Go Context

--- a/error.go
+++ b/error.go
@@ -12,6 +12,7 @@ type Error struct {
 	Msg     string
 	Status  int
 	Headers map[string]string
+	Body    string
 }
 
 func (e *Error) Error() string {
@@ -32,11 +33,11 @@ func nonHttpErr(prefix string, err error) *Error {
 	return &Error{inner: err, Msg: prefix + err.Error()}
 }
 
-func httpErr(prefix string, err error, r *http.Response) *Error {
+func httpErr(prefix string, err error, r *http.Response, body []byte) *Error {
 	if r == nil {
 		return nonHttpErr(prefix, err)
 	}
-	return &Error{inner: err, Msg: prefix + err.Error(), Status: r.StatusCode, Headers: uniqueHeaders(r.Header)}
+	return &Error{inner: err, Msg: prefix + err.Error(), Status: r.StatusCode, Headers: uniqueHeaders(r.Header), Body: string(body)}
 }
 
 // JQError is returned from J.Q on invalid syntax.

--- a/fetch.go
+++ b/fetch.go
@@ -164,7 +164,7 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 	var t T
 	typeOf := reflect.TypeOf(t)
 
-	if typeOf != nil && typeOf == typeFor[ResponseEmpty]() {
+	if typeOf != nil && typeOf == typeFor[ResponseEmpty]() && firstDigit(res.StatusCode) == 2 {
 		re := any(&t).(*ResponseEmpty)
 		re.Status = res.StatusCode
 		re.DuplicateHeaders = res.Header

--- a/fetch.go
+++ b/fetch.go
@@ -173,11 +173,11 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		return t, httpErr("read http body: ", err, res)
+		return t, httpErr("read http body: ", err, res, nil)
 	}
 
 	if firstDigit(res.StatusCode) != 2 {
-		return t, httpErr(fmt.Sprintf("http status=%d, body=", res.StatusCode), errors.New(string(body)), res)
+		return t, httpErr(fmt.Sprintf("http status=%d, body=", res.StatusCode), errors.New(string(body)), res, body)
 	}
 
 	if typeOf != nil && typeOf.PkgPath() == "github.com/glossd/fetch" && strings.HasPrefix(typeOf.Name(), "Response[") {
@@ -190,7 +190,7 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 		err = parseBodyInto(body, resInstance)
 		if err != nil {
 			var t T
-			return t, httpErr("parsing JSON error: ", err, res)
+			return t, httpErr("parsing JSON error: ", err, res, body)
 		}
 
 		valueOf := reflect.Indirect(reflect.ValueOf(&t))
@@ -204,7 +204,7 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 	err = parseBodyInto(body, &t)
 	if err != nil {
 		var t T
-		return t, httpErr("parsing JSON error: ", err, res)
+		return t, httpErr("parsing JSON error: ", err, res, body)
 	}
 	return t, nil
 }

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -116,6 +116,23 @@ func TestRequest_ResponseEmpty(t *testing.T) {
 	}
 }
 
+func TestRequest_Error(t *testing.T) {
+	_, err := Request[string]("400.error")
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	if err.Status != 400 {
+		t.Errorf("expected status 400")
+	}
+	if err.Headers["Content-type"] != "text/plain" {
+		t.Errorf("expected headers")
+	}
+	if err.Body != "Bad Request" {
+		t.Errorf("expected body")
+	}
+}
+
 func TestPostString(t *testing.T) {
 	j, err := Post[M]("echo.me", `{"hello":"whosthere"}`)
 	if err != nil {

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -111,7 +111,7 @@ func TestRequest_ResponseEmpty(t *testing.T) {
 	}
 
 	_, err = Request[ResponseEmpty]("400.error")
-	if err == nil || err.Unwrap().Error() != "Bad Request" {
+	if err == nil || err.Body != "Bad Request" {
 		t.Errorf("Even with ResponseEmpty error should read the body")
 	}
 }

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -109,6 +109,11 @@ func TestRequest_ResponseEmpty(t *testing.T) {
 	if res.Headers()["Content-type"] != "application/json" {
 		t.Errorf("wrong headers")
 	}
+
+	_, err = Request[ResponseEmpty]("400.error")
+	if err == nil || err.Unwrap().Error() != "Bad Request" {
+		t.Errorf("Even with ResponseEmpty error should read the body")
+	}
 }
 
 func TestPostString(t *testing.T) {

--- a/mock.go
+++ b/mock.go
@@ -39,7 +39,7 @@ func mockDNS(url string, req *http.Request) *mockResponse {
 	case "my.ip":
 		return &mockResponse{Status: 200, Headers: map[string][]string{"Content-type": {"text/plain"}}, Body: `8.8.8.8`}
 	case "400.error":
-		return &mockResponse{Status: 400, Body: `Bad Request`}
+		return &mockResponse{Status: 400, Headers: map[string][]string{"Content-type": {"text/plain"}}, Body: `Bad Request`}
 	case "echo.me":
 		body, err := io.ReadAll(req.Body)
 		if err != nil {

--- a/mock.go
+++ b/mock.go
@@ -38,6 +38,8 @@ func mockDNS(url string, req *http.Request) *mockResponse {
 		return &mockResponse{Status: 200, Body: `[1, 2, 3]`}
 	case "my.ip":
 		return &mockResponse{Status: 200, Headers: map[string][]string{"Content-type": {"text/plain"}}, Body: `8.8.8.8`}
+	case "400.error":
+		return &mockResponse{Status: 400, Body: `Bad Request`}
 	case "echo.me":
 		body, err := io.ReadAll(req.Body)
 		if err != nil {


### PR DESCRIPTION
ResponeEmpty did not comply with the contention that any non-2xx status is supposed to be treated as an error
Add HTTP body to the fetch.Error