### PR TITLE
Release 0.3.0, remove JQ, update headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ if resp.Status == 200 {
     fmt.Println("Found pet with id 1")
     // Response.Body is the Pet object.
     fmt.Println("Pet's name is ", resp.Body.Name)
-    fmt.Println("Response headers", resp.Headers())
+    fmt.Println("Response headers", resp.Headers)
 }
 ```
 If you don't need the HTTP body you can use `fetch.ResponseEmpty`
@@ -115,7 +115,7 @@ if err != nil {
     panic(err)
 }
 fmt.Println("Status:", res.Status)
-fmt.Println("Headers:", res.Headers())
+fmt.Println("Headers:", res.Headers)
 ```
 #### Error handling
 The error will contain the status and other http attributes. Any non-2xx response status is treated as an error.

--- a/error.go
+++ b/error.go
@@ -8,11 +8,12 @@ import (
 )
 
 type Error struct {
-	inner   error
-	Msg     string
-	Status  int
-	Headers map[string]string
-	Body    string
+	inner            error
+	Msg              string
+	Status           int
+	Headers          map[string]string
+	DuplicateHeaders map[string][]string
+	Body             string
 }
 
 func (e *Error) Error() string {
@@ -37,7 +38,14 @@ func httpErr(prefix string, err error, r *http.Response, body []byte) *Error {
 	if r == nil {
 		return nonHttpErr(prefix, err)
 	}
-	return &Error{inner: err, Msg: prefix + err.Error(), Status: r.StatusCode, Headers: uniqueHeaders(r.Header), Body: string(body)}
+	return &Error{
+		inner:            err,
+		Msg:              prefix + err.Error(),
+		Status:           r.StatusCode,
+		Headers:          uniqueHeaders(r.Header),
+		DuplicateHeaders: r.Header,
+		Body:             string(body),
+	}
 }
 
 // JQError is returned from J.Q on invalid syntax.

--- a/fetch.go
+++ b/fetch.go
@@ -167,6 +167,7 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 	if typeOf != nil && typeOf == typeFor[ResponseEmpty]() && firstDigit(res.StatusCode) == 2 {
 		re := any(&t).(*ResponseEmpty)
 		re.Status = res.StatusCode
+		re.Headers = uniqueHeaders(res.Header)
 		re.DuplicateHeaders = res.Header
 		return t, nil
 	}
@@ -196,6 +197,7 @@ func Request[T any](url string, config ...Config) (T, *Error) {
 		valueOf := reflect.Indirect(reflect.ValueOf(&t))
 		valueOf.FieldByName("Status").SetInt(int64(res.StatusCode))
 		valueOf.FieldByName("DuplicateHeaders").Set(reflect.ValueOf(res.Header))
+		valueOf.FieldByName("Headers").Set(reflect.ValueOf(uniqueHeaders(res.Header)))
 		valueOf.FieldByName("BodyBytes").SetBytes(body)
 		valueOf.FieldByName("Body").Set(reflect.ValueOf(resInstance).Elem())
 

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -81,7 +81,7 @@ func TestRequest_ResponseT(t *testing.T) {
 		t.Errorf("wrong status")
 	}
 
-	if res.Headers()["Content-type"] != "application/json" {
+	if res.Headers["Content-type"] != "application/json" {
 		t.Errorf("wrong headers")
 	}
 
@@ -106,7 +106,7 @@ func TestRequest_ResponseEmpty(t *testing.T) {
 	if res.Status != 200 {
 		t.Errorf("response status isn't 200")
 	}
-	if res.Headers()["Content-type"] != "application/json" {
+	if res.Headers["Content-type"] != "application/json" {
 		t.Errorf("wrong headers")
 	}
 

--- a/j.go
+++ b/j.go
@@ -295,13 +295,6 @@ func (n Nil) AsString() (string, bool)         { return "", false }
 func (n Nil) AsBoolean() (bool, bool)          { return false, false }
 func (n Nil) IsNil() bool                      { return true }
 
-// Deprecated, use fetch.Parse(jsonStr).Q(pattern)
-// JQ parses jsonStr into fetch.J
-// and calls J.Q method with the pattern.
-func JQ(jsonStr, pattern string) J {
-	return Parse(jsonStr).Q(pattern)
-}
-
 func isJNil(v any) bool {
 	return v == nil || reflect.TypeOf(v) == typeFor[Nil]()
 }

--- a/j_test.go
+++ b/j_test.go
@@ -221,15 +221,6 @@ func TestJ_AsSecondValue(t *testing.T) {
 	}
 }
 
-func TestJQ(t *testing.T) {
-	if JQ(`{"key":"value"}`, ".key").String() != "value" {
-		t.Errorf("JQ mismatch")
-	}
-	if !JQ(`{`, ".key").IsNil() {
-		t.Errorf("JQ parsed invalid json")
-	}
-}
-
 func mustUnmarshal(s string) J {
 	j, err := Unmarshal[J](s)
 	if err != nil {

--- a/response.go
+++ b/response.go
@@ -5,6 +5,7 @@ Response is a wrapper type for (generic) ReturnType to be used in
 the HTTP methods. It allows you to access HTTP attributes
 of the HTTP response and unmarshal the HTTP body.
 e.g.
+
 	type User struct {
 		FirstName string
 	}
@@ -17,25 +18,22 @@ e.g.
 	fmt.Println(res.Body.FirstName)
 */
 type Response[T any] struct {
-	Status           int
+	Status int
+	// HTTP headers are not unique.
+	// In the majority of the cases Headers is enough.
+	// Headers are filled with the last value from DuplicateHeaders.
 	DuplicateHeaders map[string][]string
+	Headers          map[string]string
 	Body             T
 	BodyBytes        []byte
-}
-
-func (r Response[T]) Headers() map[string]string {
-	return uniqueHeaders(r.DuplicateHeaders)
 }
 
 // ResponseEmpty is a special ResponseType that completely ignores the HTTP body.
 // Can be used as the (generic) ReturnType for any HTTP method.
 type ResponseEmpty struct {
 	Status           int
+	Headers          map[string]string
 	DuplicateHeaders map[string][]string
-}
-
-func (r ResponseEmpty) Headers() map[string]string {
-	return uniqueHeaders(r.DuplicateHeaders)
 }
 
 func uniqueHeaders(headers map[string][]string) map[string]string {


### PR DESCRIPTION
fetch.JQ was deprecated for while, I planned to delete it.
fetch.Response, ResponseEmpty and Error have the same Headers and DuplicateHeaders fields
Fixes #18 