### PR TITLE
Replace *fetch.Error with error

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ fmt.Println("Status:", res.Status)
 fmt.Println("Headers:", res.Headers)
 ```
 #### Error handling
-Any non-2xx response status is treated as an error!
-If the error isn't nil, it can be safely cast to `*fetch.Error` which will contain the status and other HTTP attributes. 
+Any **non-2xx** response status is treated as an **error**!
+If the error isn't `nil` it can be safely cast to `*fetch.Error` which will contain the status and other HTTP attributes. 
 ```go
 _, err := fetch.Get[string]("https://petstore.swagger.io/v2/pet/-1")
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ fmt.Println("Status:", res.Status)
 fmt.Println("Headers:", res.Headers)
 ```
 #### Error handling
-The error will contain the status and other http attributes. Any non-2xx response status is treated as an error.
+Any non-2xx response status is treated as an error!
+If the error isn't nil, it can be safely cast to `*fetch.Error` which will contain the status and other HTTP attributes. 
 ```go
 _, err := fetch.Get[string]("https://petstore.swagger.io/v2/pet/-1")
 if err != nil {
-    fmt.Printf("Get pet failed: %s", err)
-    fmt.Printf("HTTP status=%d, headers=%v, body=%s", err.Status, err.Headers, err.Body)
+    fmt.Printf("Get pet failed: %s\n", err)
+    ferr := err.(*fetch.Error)
+    fmt.Printf("HTTP status=%d, headers=%v, body=%s", ferr.Status, ferr.Headers, ferr.Body)
 }
 ```
 ### Make request with Go Context

--- a/fetch.go
+++ b/fetch.go
@@ -24,7 +24,7 @@ type Config struct {
 	Headers map[string]string
 }
 
-func Get[T any](url string, config ...Config) (T, *Error) {
+func Get[T any](url string, config ...Config) (T, error) {
 	if len(config) == 0 {
 		config = []Config{{}}
 	}
@@ -33,23 +33,23 @@ func Get[T any](url string, config ...Config) (T, *Error) {
 }
 
 // GetJ is a wrapper for Get[fetch.J]
-func GetJ(url string, config ...Config) (J, *Error) {
+func GetJ(url string, config ...Config) (J, error) {
 	return Get[J](url, config...)
 }
 
-func Post[T any](url string, body any, config ...Config) (T, *Error) {
+func Post[T any](url string, body any, config ...Config) (T, error) {
 	return requestWithBody[T](url, http.MethodPost, body, config...)
 }
 
-func Put[T any](url string, body any, config ...Config) (T, *Error) {
+func Put[T any](url string, body any, config ...Config) (T, error) {
 	return requestWithBody[T](url, http.MethodPut, body, config...)
 }
 
-func Patch[T any](url string, body any, config ...Config) (T, *Error) {
+func Patch[T any](url string, body any, config ...Config) (T, error) {
 	return requestWithBody[T](url, http.MethodPatch, body, config...)
 }
 
-func requestWithBody[T any](url string, method string, body any, config ...Config) (T, *Error) {
+func requestWithBody[T any](url string, method string, body any, config ...Config) (T, error) {
 	if len(config) == 0 {
 		config = []Config{{}}
 	}
@@ -73,7 +73,7 @@ func bodyToString(v any) (string, error) {
 	return Marshal(v)
 }
 
-func Delete[T any](url string, config ...Config) (T, *Error) {
+func Delete[T any](url string, config ...Config) (T, error) {
 	if len(config) == 0 {
 		config = []Config{{}}
 	}
@@ -81,7 +81,7 @@ func Delete[T any](url string, config ...Config) (T, *Error) {
 	return Request[T](url, config...)
 }
 
-func Head[T any](url string, config ...Config) (T, *Error) {
+func Head[T any](url string, config ...Config) (T, error) {
 	if len(config) == 0 {
 		config = []Config{{}}
 	}
@@ -89,7 +89,7 @@ func Head[T any](url string, config ...Config) (T, *Error) {
 	return Request[T](url, config...)
 }
 
-func Options[T any](url string, config ...Config) (T, *Error) {
+func Options[T any](url string, config ...Config) (T, error) {
 	if len(config) == 0 {
 		config = []Config{{}}
 	}
@@ -97,7 +97,7 @@ func Options[T any](url string, config ...Config) (T, *Error) {
 	return Request[T](url, config...)
 }
 
-func Request[T any](url string, config ...Config) (T, *Error) {
+func Request[T any](url string, config ...Config) (T, error) {
 	var cfg Config
 	if len(config) > 0 {
 		cfg = config[0]

--- a/fetch_it_test.go
+++ b/fetch_it_test.go
@@ -41,11 +41,11 @@ func TestRequestIntegration(t *testing.T) {
 		t.Fatalf("expected 303 status error")
 	}
 
-	if err.Status != 303 {
-		t.Fatalf("expected 303 status, got=%d", err.Status)
+	if err.(*Error).Status != 303 {
+		t.Fatalf("expected 303 status, got=%d", err.(*Error).Status)
 	}
-	if err.Headers["Access-Control-Allow-Origin"] != "noone.com" {
-		t.Fatalf("expected header, got=%s", err.Headers["Access-Control-Allow-Origin"])
+	if err.(*Error).Headers["Access-Control-Allow-Origin"] != "noone.com" {
+		t.Fatalf("expected header, got=%s", err.(*Error).Headers["Access-Control-Allow-Origin"])
 	}
 	if err.Error() != "http status=303, body=wrong neighborhood" {
 		t.Fatalf("wrong error message, got=%s", err)

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -111,7 +111,7 @@ func TestRequest_ResponseEmpty(t *testing.T) {
 	}
 
 	_, err = Request[ResponseEmpty]("400.error")
-	if err == nil || err.Body != "Bad Request" {
+	if err == nil || err.(*Error).Body != "Bad Request" {
 		t.Errorf("Even with ResponseEmpty error should read the body")
 	}
 }
@@ -122,13 +122,14 @@ func TestRequest_Error(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err.Status != 400 {
+	castErr := err.(*Error)
+	if castErr.Status != 400 {
 		t.Errorf("expected status 400")
 	}
-	if err.Headers["Content-type"] != "text/plain" {
+	if castErr.Headers["Content-type"] != "text/plain" {
 		t.Errorf("expected headers")
 	}
-	if err.Body != "Bad Request" {
+	if castErr.Body != "Bad Request" {
 		t.Errorf("expected body")
 	}
 }
@@ -150,5 +151,13 @@ func TestPostBytes(t *testing.T) {
 	}
 	if j["hello"] != "whosthere" {
 		t.Errorf("wrong post response")
+	}
+}
+
+func TestIssue20(t *testing.T) {
+	var err error
+	_, err = Get[J]("key.value")
+	if err != nil {
+		t.Errorf("err should be nil")
 	}
 }


### PR DESCRIPTION
Errors in Golang are usually being used again, and the standard `error` interface is used everywhere.
Returning `*fetch.Error` was a mistake because with `var err error` being declared before, `err` would have a type.
Quick example
```go
func main() {
	var err error
	f := func() *fetch.Error {
		return nil
	}
	err = f()
	if err != nil {
		panic(err)
	}
}
```
It's a problem that requires to break the contract. 

Fixes #20 