### PR TITLE
Release v0.5, Go 1.22, Upgrade ToHandleFunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 
 ## Installing
-This is a zero-dependency package. It requires Go version 1.21 or above.
+This is a zero-dependency package. It requires Go version 1.22 or above.
 ```shell
 go get github.com/glossd/fetch
 ```
@@ -287,7 +287,8 @@ type Config struct {
 ```
 
 ## HTTP handlers
-`fetch.ToHandlerFunc` allows you to convert `func(in) out, error` signature function into `http.HandlerFunc`.
+With `fetch.ToHandlerFunc` you could completely omit 
+`fetch.ToHandlerFunc` accepts `func(in) out, error` signature function and converts it into `http.HandlerFunc`.
 It unmarshals the HTTP request body into the function argument, then marshals the returned value into the HTTP response body.
 ```go
 // accepts Pet object and returns Pet object
@@ -303,8 +304,21 @@ http.ListenAndServe(":8080", nil)
 ```
 If you don't need request or response body, use `fetch.Empty` to fit the function signature.
 ```go
-http.HandleFunc("GET /pets/1", fetch.ToHandlerFunc(func(_ fetch.Empty) (Pet, error) {
+http.HandleFunc("GET /default-pet", fetch.ToHandlerFunc(func(_ fetch.Empty) (Pet, error) {
     return Pet{Id: 1}, nil
+}))
+```
+If you need to access path value or HTTP header use tags below:
+```go
+type Pet struct {
+    Id int `pathval:"id"` // pathval must match the wildcard in the url pattern.
+    Auth string `header:"Authorization"`
+	Name string
+}
+http.HandleFunc("GET /pets/{id}", fetch.ToHandlerFunc(func(in Pet) (fetch.Empty, error) {
+    fmt.Println("Pet's id from url:", in.Id)
+    fmt.Println("Authorization header:", in.Auth)
+    return fetch.Empty{}, nil
 }))
 ```
 The error format can be customized with the `fetch.SetRespondErrorFormat` global setter.  
@@ -313,5 +327,15 @@ To log http errors with your logger call `SetDefaultHandlerConfig`
 fetch.SetDefaultHandlerConfig(fetch.HandlerConfig{ErrorHook: func(err error) {
     mylogger.Errorf("fetch http error: %s", err)
 }})
+```
+To add middleware before handling request in `fetch.ToHandlerFunc`  
+```go 
+fetch.SetDefaultHandlerConfig(fetch.HandlerConfig{Middleware: func(w http.ResponseWriter, r *http.Request) bool {
+    if r.Header.Get("Authorization") == "" {
+        w.WriteHeader(401)
+        return true
+    }
+    return false
+},})
 ```
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ If you need to access path value or HTTP header use tags below:
 type Pet struct {
     Id int `pathval:"id"` // pathval must match the wildcard in the url pattern.
     Auth string `header:"Authorization"`
-	Name string
+    Name string
 }
 http.HandleFunc("GET /pets/{id}", fetch.ToHandlerFunc(func(in Pet) (fetch.Empty, error) {
     fmt.Println("Pet's id from url:", in.Id)

--- a/error.go
+++ b/error.go
@@ -90,14 +90,5 @@ func jqerr(format string, a ...any) *JQError {
 }
 
 func IsJQError(v any) bool {
-	return reflect.TypeOf(v) == typeFor[*JQError]()
-}
-
-// reflect.TypeFor was introduced in go1.22
-func typeFor[T any]() reflect.Type {
-	var v T
-	if t := reflect.TypeOf(v); t != nil {
-		return t
-	}
-	return reflect.TypeOf((*T)(nil)).Elem()
+	return reflect.TypeOf(v) == reflect.TypeFor[*JQError]()
 }

--- a/fetch.go
+++ b/fetch.go
@@ -164,10 +164,10 @@ func Request[T any](url string, config ...Config) (T, error) {
 	var t T
 	typeOf := reflect.TypeOf(t)
 
-	if typeOf != nil && typeOf == typeFor[Empty]() && firstDigit(res.StatusCode) == 2 {
+	if typeOf != nil && typeOf == reflect.TypeFor[Empty]() && firstDigit(res.StatusCode) == 2 {
 		return t, nil
 	}
-	if typeOf != nil && typeOf == typeFor[ResponseEmpty]() && firstDigit(res.StatusCode) == 2 {
+	if typeOf != nil && typeOf == reflect.TypeFor[ResponseEmpty]() && firstDigit(res.StatusCode) == 2 {
 		re := any(&t).(*ResponseEmpty)
 		re.Status = res.StatusCode
 		re.Headers = uniqueHeaders(res.Header)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/glossd/fetch
 
-go 1.21
+go 1.22

--- a/j.go
+++ b/j.go
@@ -296,7 +296,7 @@ func (n Nil) AsBoolean() (bool, bool)          { return false, false }
 func (n Nil) IsNil() bool                      { return true }
 
 func isJNil(v any) bool {
-	return v == nil || reflect.TypeOf(v) == typeFor[Nil]()
+	return v == nil || reflect.TypeOf(v) == reflect.TypeFor[Nil]()
 }
 
 func nextSep(pattern string) (int, string) {

--- a/parse.go
+++ b/parse.go
@@ -48,7 +48,7 @@ func UnmarshalInto(j string, v any) error {
 
 	rve := rv.Elem()
 	var isAny = rve.Kind() == reflect.Interface && rve.NumMethod() == 0
-	if isAny || rve.Type() == typeFor[J]() {
+	if isAny || rve.Type() == reflect.TypeFor[J]() {
 		var a any
 		err := json.Unmarshal([]byte(j), &a)
 		if err != nil {

--- a/respond.go
+++ b/respond.go
@@ -39,6 +39,7 @@ type RespondConfig struct {
 	ErrorStatus int
 }
 
+// Deprecated, rely on ToHandlerFunc.
 // Respond tries to marshal the body and send HTTP response.
 // The HTTP response is sent even if an error occurs.
 // It should be used for the standard HTTP handlers.
@@ -78,6 +79,10 @@ func Respond(w http.ResponseWriter, body any, config ...RespondConfig) error {
 		bodyStr = ""
 		isString = true
 	}
+	if body == nil {
+		bodyStr = ""
+		isString = true
+	}
 	if !isString {
 		bodyStr, err = Marshal(body)
 		if err != nil {
@@ -103,6 +108,7 @@ func respond(w http.ResponseWriter, status int, bodyStr string, isJSON bool, cfg
 	return err
 }
 
+// Deprecated, rely on ToHandlerFunc.
 // RespondError sends HTTP response in the error format of Respond.
 // It should be used when your handler experiences an error
 // before marshalling and responding with fetch.Respond.

--- a/to_handler.go
+++ b/to_handler.go
@@ -5,40 +5,63 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strconv"
 )
 
 var defaultHandlerConfig = HandlerConfig{
 	ErrorHook: func(err error) {
 		fmt.Printf("fetch.Handle failed to respond: %s\n", err)
 	},
+	Middleware: func(w http.ResponseWriter, r *http.Request) bool {
+		return false
+	},
 }
 
-// SetDefaultHandleConfig sets default HandlerConfig globally.
+// SetDefaultHandlerConfig sets HandlerConfig globally to be applied for every ToHandlerFunc.
 func SetDefaultHandlerConfig(hc HandlerConfig) {
+	if hc.ErrorHook == nil {
+		hc.ErrorHook = defaultHandlerConfig.ErrorHook
+	}
+	if hc.Middleware == nil {
+		hc.Middleware = defaultHandlerConfig.Middleware
+	}
 	defaultHandlerConfig = hc
 }
 
 type HandlerConfig struct {
 	// ErrorHook is called if an error happens while sending an HTTP response
 	ErrorHook func(err error)
+	// Middleware is applied before ToHandlerFunc processes the request.
+	// Return true if to end the request processing.
+	Middleware func(w http.ResponseWriter, r *http.Request) bool
 }
 
 // ApplyFunc represents a simple function to be converted to http.Handler with
 // In type as a request body and Out type as a response body.
 type ApplyFunc[In any, Out any] func(in In) (Out, error)
 
-// ToHandlerFunc converts ApplyFunc into http.HandlerFunc,
-// which can be used later in http.ServeMux#HandleFunc.
-// It unmarshals the HTTP request body into the ApplyFunc argument and
-// then marshals the returned value into the HTTP response body.
-func ToHandlerFunc[In any, Out any](apply ApplyFunc[In, Out], config ...HandlerConfig) http.HandlerFunc {
+/*
+ToHandlerFunc converts ApplyFunc into http.HandlerFunc,
+which can be used later in http.ServeMux#HandleFunc.
+It unmarshals the HTTP request body into the ApplyFunc argument and
+then marshals the returned value into the HTTP response body.
+To add PathValue into the unmarshaled entity, specify `pathval` tag
+to match the wildcard in the pattern:
+
+	type Pet struct {
+	    Id int `pathval:"id"`
+	}
+
+`header` tag can be used to add HTTP headers.
+*/
+func ToHandlerFunc[In any, Out any](apply ApplyFunc[In, Out]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		cfg := defaultHandlerConfig
-		if len(config) > 0 {
-			cfg = config[0]
+		if cfg.Middleware(w, r) {
+			return
 		}
 		var in In
-		if typeFor[In]() != reflect.TypeOf(Empty{}) {
+		if reflect.TypeFor[In]() != reflect.TypeOf(Empty{}) {
 			reqBody, err := io.ReadAll(r.Body)
 			if err != nil {
 				cfg.ErrorHook(err)
@@ -58,6 +81,7 @@ func ToHandlerFunc[In any, Out any](apply ApplyFunc[In, Out], config ...HandlerC
 				return
 			}
 		}
+		in = enrichEntity(in, r)
 		out, err := apply(in)
 		if err != nil {
 			err = RespondError(w, 500, err)
@@ -71,4 +95,42 @@ func ToHandlerFunc[In any, Out any](apply ApplyFunc[In, Out], config ...HandlerC
 			cfg.ErrorHook(err)
 		}
 	}
+}
+
+func enrichEntity[T any](entity T, r *http.Request) T {
+	typeOf := reflect.TypeOf(entity)
+	if typeOf.Kind() == reflect.Pointer {
+		typeOf = reflect.ValueOf(entity).Elem().Type()
+	}
+	if typeOf.Kind() != reflect.Struct {
+		return entity
+	}
+	var elem reflect.Value
+	if reflect.TypeOf(entity).Kind() == reflect.Pointer {
+		elem = reflect.ValueOf(entity).Elem()
+	} else { // struct
+		elem = reflect.ValueOf(&entity).Elem()
+	}
+	for i := 0; i < typeOf.NumField(); i++ {
+		field := typeOf.Field(i)
+		if header := field.Tag.Get("header"); header != "" {
+			elem.Field(i).SetString(r.Header.Get(header))
+		}
+		if pathval := field.Tag.Get("pathval"); pathval != "" {
+			pathvar := r.PathValue(pathval)
+			if pathvar != "" {
+				switch field.Type.Kind() {
+				case reflect.String:
+					elem.Field(i).SetString(pathvar)
+				case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+					valInt64, err := strconv.ParseInt(pathvar, 10, 64)
+					if err != nil {
+						continue
+					}
+					elem.Field(i).SetInt(valInt64)
+				}
+			}
+		}
+	}
+	return entity
 }

--- a/to_handler.go
+++ b/to_handler.go
@@ -45,14 +45,18 @@ ToHandlerFunc converts ApplyFunc into http.HandlerFunc,
 which can be used later in http.ServeMux#HandleFunc.
 It unmarshals the HTTP request body into the ApplyFunc argument and
 then marshals the returned value into the HTTP response body.
-To add PathValue into the unmarshaled entity, specify `pathval` tag
-to match the wildcard in the pattern:
+To insert PathValue into a field of the unmarshaled entity, specify `pathval` tag
+to match the pattern's wildcard:
 
-	type Pet struct {
-	    Id int `pathval:"id"`
-	}
+type Pet struct {
+	Id int `pathval:"id"`
+}
 
-`header` tag can be used to add HTTP headers.
+`header` tag can be used to insert HTTP headers into struct field.
+
+type Pet struct {
+	Content string `header:"Content-Type"`
+}
 */
 func ToHandlerFunc[In any, Out any](apply ApplyFunc[In, Out]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/to_handler_test.go
+++ b/to_handler_test.go
@@ -30,3 +30,84 @@ func TestToHandlerFunc_EmptyOut(t *testing.T) {
 	assert(t, mw.status, 200)
 	assert(t, string(mw.body), ``)
 }
+
+func TestToHandlerFunc_MultiplePathValue(t *testing.T) {
+	type Pet struct {
+		Category string `pathval:"category"`
+		Id       string `pathval:"id"`
+		Name     string
+	}
+	f := ToHandlerFunc(func(in Pet) (Empty, error) {
+		assert(t, in.Category, "cats")
+		assert(t, in.Id, "1")
+		assert(t, in.Name, "Charles")
+		return Empty{}, nil
+	})
+	mw := newMockWriter()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /categories/{category}/ids/{id}", f)
+	r, err := http.NewRequest("POST", "/categories/cats/ids/1", bytes.NewBuffer([]byte(`{"name":"Charles"}`)))
+	assert(t, err, nil)
+	mux.ServeHTTP(mw, r)
+	assert(t, mw.status, 200)
+}
+
+func TestToHandlerFunc_ParseInt(t *testing.T) {
+	type Pet struct {
+		Id   int `pathval:"id"`
+		Name string
+	}
+	f := ToHandlerFunc(func(in Pet) (Empty, error) {
+		assert(t, in.Id, 1)
+		assert(t, in.Name, "Charles")
+		return Empty{}, nil
+	})
+	mw := newMockWriter()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /ids/{id}", f)
+	r, err := http.NewRequest("POST", "/ids/1", bytes.NewBuffer([]byte(`{"name":"Charles"}`)))
+	assert(t, err, nil)
+	mux.ServeHTTP(mw, r)
+	assert(t, mw.status, 200)
+}
+
+func TestToHandlerFunc_Header(t *testing.T) {
+	type Pet struct {
+		Content string `header:"Content"`
+	}
+	f := ToHandlerFunc(func(in Pet) (Empty, error) {
+		assert(t, in.Content, "mycontent")
+		return Empty{}, nil
+	})
+	mw := newMockWriter()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /pets", f)
+	r, err := http.NewRequest("POST", "/pets", bytes.NewBuffer([]byte(`{}`)))
+	r.Header.Set("Content", "mycontent")
+	assert(t, err, nil)
+	mux.ServeHTTP(mw, r)
+	assert(t, mw.status, 200)
+}
+
+func TestToHandlerFunc_Middleware(t *testing.T) {
+	SetDefaultHandlerConfig(HandlerConfig{
+		Middleware: func(w http.ResponseWriter, r *http.Request) bool {
+			w.WriteHeader(422)
+			return true
+		},
+	})
+	defer SetDefaultHandlerConfig(HandlerConfig{Middleware: func(w http.ResponseWriter, r *http.Request) bool {
+		return false
+	}})
+
+	f := ToHandlerFunc(func(in Empty) (Empty, error) {
+		return Empty{}, nil
+	})
+	mw := newMockWriter()
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /pets", f)
+	r, err := http.NewRequest("POST", "/pets", bytes.NewBuffer([]byte(`{}`)))
+	assert(t, err, nil)
+	mux.ServeHTTP(mw, r)
+	assert(t, mw.status, 422)
+}


### PR DESCRIPTION
To include parsing of the PathValue, I have to upgrade the supported Golang version to 1.22 which came with Enhanced routing.