### PR TITLE
Alias for empty Request and Response

### DIFF
--- a/fetch_test.go
+++ b/fetch_test.go
@@ -114,6 +114,17 @@ func TestDo_ResponseEmpty(t *testing.T) {
 	if err == nil || err.(*Error).Body != "Bad Request" {
 		t.Errorf("Even with ResponseEmpty error should read the body")
 	}
+
+	resEm, err := Do[ResponseEmpty]("key.value")
+	if err != nil {
+		t.Error(err)
+	}
+	if resEm.Status != 200 {
+		t.Errorf("response status isn't 200")
+	}
+	if resEm.Headers["Content-type"] != "application/json" {
+		t.Errorf("wrong headers")
+	}
 }
 
 func TestDo_Error(t *testing.T) {

--- a/to_handler_test.go
+++ b/to_handler_test.go
@@ -32,6 +32,19 @@ func TestToHandlerFunc_EmptyOut(t *testing.T) {
 	assert(t, mw.body, ``)
 }
 
+
+func TestToHandlerFunc_RequestEmpty(t *testing.T) {
+	f := ToHandlerFunc(func(in RequestEmpty) (J, error) {
+		return M{"name": "Lola"}, nil
+	})
+	mw := newMockWriter()
+	r, err := http.NewRequest("", "", bytes.NewBuffer(nil))
+	assert(t, err, nil)
+	f(mw, r)
+	assert(t, mw.status, 200)
+	assert(t, mw.body, `{"name":"Lola"}`)
+}
+
 // This test should fail to compile on go1.21 and successfully run on go1.22.
 // Don't forget to update go.mod to 1.22 before running.
 //func TestToHandlerFunc_MultiplePathValue(t *testing.T) {

--- a/wrappers.go
+++ b/wrappers.go
@@ -98,6 +98,10 @@ func (r Request[T]) WithHeader(name, value string) Request[T] {
 // Can be used with the wrappers Response and Request or to fit the signature of ApplyFunc.
 type Empty struct{}
 
+
+type ResponseEmpty = Response[Empty]
+type RequestEmpty = Request[Empty]
+
 func isResponseWrapper(v any) bool {
 	if v == nil {
 		return false


### PR DESCRIPTION
`ResponseEmpty` and `RequestEmpty`